### PR TITLE
Fix sessions method

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -368,8 +368,11 @@ print.bids_project <- function(x, ...) {
 #' @rdname sessions-method
 #' @method sessions bids_project
 sessions.bids_project <- function(x) {
-  if (x$has_session) {
-    unique(unlist(x$bids_tree$Get("session", filterFun = function(x) !is.null(x$session))))
+  if (x$has_sessions) {
+    sort(unique(unlist(x$bids_tree$Get(
+      "session",
+      filterFun = function(node) !is.null(node$session)
+    ))))
   } else {
     NULL
   }

--- a/tests/testthat/test_sessions.R
+++ b/tests/testthat/test_sessions.R
@@ -1,0 +1,12 @@
+context("sessions")
+library(testthat)
+library(bidser)
+
+# Ensure sessions() returns session IDs for datasets with sessions
+
+test_that("sessions() extracts session IDs when present", {
+  proj <- bids_project(system.file("extdata/ds114", package = "bidser"), fmriprep = FALSE)
+  ses <- sessions(proj)
+  expect_true(!is.null(ses))
+  expect_equal(sort(ses), c("retest", "test"))
+})


### PR DESCRIPTION
## Summary
- fix `sessions.bids_project` to use `has_sessions`
- ensure returned sessions are sorted unique values
- add unit test for dataset with sessions

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: `Rscript: command not found`)*