### PR TITLE
Handle missing fMRIPrep derivatives

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -548,6 +548,12 @@ preproc_scans.bids_project <- function(x, subid=".*", task=".*", run=".*", varia
   f <- function(node) paste0(node$path[2:length(node$path)], collapse="/")
   
   pdir <- x$prep_dir
+
+  # check that fMRIPrep derivatives are available
+  if (!x$has_fmriprep || !(pdir %in% names(x$bids_tree$children))) {
+    message("fMRIPrep derivatives not found; returning NULL.")
+    return(NULL)
+  }
   
   # If variant is NULL, treat it as ".*"
   var_pattern <- if (is.null(variant)) ".*" else variant

--- a/tests/testthat/test_preproc_scans.R
+++ b/tests/testthat/test_preproc_scans.R
@@ -86,9 +86,15 @@ test_that("combining multiple filters works correctly", {
 
 test_that("attempt to find preproc scans with non-existent id returns NULL", {
   skip_if_not(has_phoneme_data(), "Phoneme dataset with fmriprep derivatives not available")
-  
+
   proj <- bids_project(system.file("extdata/phoneme_stripped", package="bidser"), fmriprep=TRUE)
   pscans <- preproc_scans(proj, subid="nonexistent")
+  expect_null(pscans)
+})
+
+test_that("returns NULL when project lacks fmriprep data", {
+  proj <- bids_project(system.file("extdata/ds001", package="bidser"), fmriprep=FALSE)
+  pscans <- preproc_scans(proj)
   expect_null(pscans)
 })
 


### PR DESCRIPTION
## Summary
- guard `preproc_scans()` against missing derivatives
- test that `preproc_scans()` returns `NULL` when derivatives are absent

## Testing
- `Rscript -e "devtools::test()"` *(fails: `Rscript: command not found`)*