### PR TITLE
Remove unused argument

### DIFF
--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -209,10 +209,9 @@ DEFAULT_CVARS2 <- c("csf", "white_matter", "global_signal", "std_dvars",
 #' @param subid Subject ID regex
 #' @param task Task regex
 #' @param session Session regex
-#' @param nest If TRUE, results are nested
 #' @return A character vector of file paths
 #' @export
-confound_files.bids_project <- function(x, subid=".*", task=".*", session=".*", nest=TRUE) {
+confound_files.bids_project <- function(x, subid=".*", task=".*", session=".*") {
   if (!inherits(x, "bids_project")) {
     stop("`x` must be a `bids_project` object.")
   }
@@ -276,7 +275,7 @@ read_confounds.bids_project <- function(x, subid=".*", task=".*", session=".*", 
   
   ret <- lapply(sids, function(s) {
     # Use confound_files to get all possible confound files
-    fnames <- confound_files(x, subid=paste0("^", as.character(s), "$"), task=task, session=session, nest=FALSE)
+    fnames <- confound_files(x, subid=paste0("^", as.character(s), "$"), task=task, session=session)
     
     # Filter by run if specified
     if (run != ".*") {

--- a/man/confound_files.bids_project.Rd
+++ b/man/confound_files.bids_project.Rd
@@ -4,7 +4,7 @@
 \alias{confound_files.bids_project}
 \title{Locate confound files}
 \usage{
-\method{confound_files}{bids_project}(x, subid = ".*", task = ".*", session = ".*", nest = TRUE)
+\method{confound_files}{bids_project}(x, subid = ".*", task = ".*", session = ".*")
 }
 \arguments{
 \item{x}{A \code{bids_project} object}
@@ -15,7 +15,6 @@
 
 \item{session}{Session regex}
 
-\item{nest}{If TRUE, results are nested}
 }
 \value{
 A character vector of file paths


### PR DESCRIPTION
## Summary
- remove unused `nest` argument from `confound_files.bids_project`
- adjust documentation accordingly
- update call in `read_confounds`

## Testing
- `R` was not available so no tests were run