### PR TITLE
Check thresh range in mask creation

### DIFF
--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -127,7 +127,9 @@ read_preproc_scans.bids_project <- function(x, mask=NULL, mode = c("normal", "bi
 #'
 #' @param x A \code{bids_project} object with fMRIPrep derivatives
 #' @param subid Regular expression to match subject IDs (e.g., "01" for subject 01, ".*" for all subjects)
-#' @param thresh Threshold value between 0 and 1 (default 0.99) - voxels with values below this threshold are excluded from the mask
+#' @param thresh Threshold value between 0 and 1 (default 0.99). Values outside
+#'   this range will trigger an error. Voxels with values below the threshold are
+#'   excluded from the mask.
 #' @param ... Additional arguments passed to \code{search_files} for finding mask files
 #'
 #' @return A logical mask volume (\code{LogicalNeuroVol}) that can be used for subsequent analyses with preprocessed functional data.
@@ -164,6 +166,10 @@ read_preproc_scans.bids_project <- function(x, mask=NULL, mode = c("normal", "bi
 create_preproc_mask.bids_project <- function(x, subid, thresh=.99, ...) {
   if (!inherits(x, "bids_project")) {
     stop("`x` must be a `bids_project` object.")
+  }
+
+  if (!is.numeric(thresh) || length(thresh) != 1 || thresh < 0 || thresh > 1) {
+    stop("`thresh` must be between 0 and 1.")
   }
   
   if (!x$has_fmriprep) {

--- a/tests/testthat/test_preproc_mask.R
+++ b/tests/testthat/test_preproc_mask.R
@@ -1,0 +1,20 @@
+context("preproc_mask")
+library(testthat)
+library(bidser)
+
+# Helper to check if phoneme_stripped dataset with fmriprep derivatives is available
+has_phoneme_data <- function() {
+  test_path <- system.file("extdata/phoneme_stripped/derivatives/fmriprep", package="bidser")
+  nchar(test_path) > 0 && dir.exists(test_path)
+}
+
+# Error if thresh out of range
+
+test_that("create_preproc_mask errors for invalid thresh", {
+  skip_if_not(has_phoneme_data(), "Phoneme dataset with fmriprep derivatives not available")
+
+  proj <- bids_project(system.file("extdata/phoneme_stripped", package="bidser"), fmriprep=TRUE)
+  expect_error(create_preproc_mask(proj, subid="1001", thresh=1.5), "thresh")
+  expect_error(create_preproc_mask(proj, subid="1001", thresh=-0.1), "thresh")
+})
+


### PR DESCRIPTION
## Summary
- validate that the `thresh` argument to `create_preproc_mask()` is in the 0-1 range
- document the new range check
- test error handling for invalid threshold values

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*