### PR TITLE
Add session support to event reading

### DIFF
--- a/man/read_events.bids_project.Rd
+++ b/man/read_events.bids_project.Rd
@@ -22,22 +22,23 @@
 \value{
 A nested tibble with columns:
 \itemize{
-\item \code{.subid}: Subject ID
 \item \code{.task}: Task name
-\item \code{.run}: Run number
 \item \code{.session}: Session ID (if present)
+\item \code{.run}: Run number
+\item \code{.subid}: Subject ID
 \item \code{data}: A nested tibble containing the event data with columns:
 \itemize{
 \item \code{onset}: Event onset time in seconds
 \item \code{duration}: Event duration in seconds
 \item Additional task-specific columns (e.g., trial type, response, accuracy)
 If no matching data is found, returns an empty tibble with appropriate columns.
+Run and session identifiers are parsed from filenames using \code{func_parser()}.
 }
 }
 }
 \description{
 Reads and nests event files for given subjects and tasks from a \code{bids_project} object.
-Returns a nested tibble with event data grouped by task, run, and subject. Event files
+Returns a nested tibble with event data grouped by task, session, run, and subject. Event files
 typically contain trial-by-trial information for task-based fMRI data, including onset times,
 durations, trial types, and other task-specific variables.
 }

--- a/tests/testthat/test_events.R
+++ b/tests/testthat/test_events.R
@@ -28,3 +28,17 @@ test_that("can read in event files from a  single subject", {
   ev <- read_events(proj, subid="01")
   testthat::expect_equal(nrow(ev), 3)
 })
+
+test_that("run filtering works", {
+  proj <- bids_project(system.file("extdata/ds001", package="bidser"), fmriprep=FALSE)
+  ev <- read_events(proj, run="02")
+  testthat::expect_equal(nrow(ev), 16)
+  testthat::expect_true(all(ev$.run == "02"))
+})
+
+test_that("session filtering works", {
+  proj <- bids_project(system.file("extdata/ds114", package="bidser"), fmriprep=FALSE)
+  ev <- read_events(proj, session="test")
+  testthat::expect_equal(nrow(ev), 10)
+  testthat::expect_true(all(ev$.session == "test"))
+})


### PR DESCRIPTION
## Summary
- extend `read_events()` with `.session` metadata
- parse run and session from filenames
- group events by session
- document `.session` in docs
- test run and session filtering

## Testing
- `Rscript -e "devtools::document()"` *(fails: command not found)*
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*