### PR TITLE
Fix optional parser repetition

### DIFF
--- a/R/match_helpers.R
+++ b/R/match_helpers.R
@@ -21,7 +21,7 @@ alt_extractor <- function(x) {
 #'
 #' @param label The label of the key to parse.
 #' @param regex A regex pattern that the key's value should match.
-#' @return A parser that matches zero or more occurrences of `_<label>-<id>`
+#' @return A parser that matches zero or one occurrence of `_<label>-<id>`
 #' @keywords internal
 optional_key <- function(label, regex = "[A-Za-z0-9]+") {
   if (!is.character(label) || length(label) != 1) {
@@ -32,7 +32,8 @@ optional_key <- function(label, regex = "[A-Za-z0-9]+") {
     pSeq(
       function(value) { value[[4]]$value },
       pLiteral("_"), pLiteral(label), pLiteral("-"), pRegex("id", regex)
-    )
+    ),
+    max = 1
   )
 }
 
@@ -56,7 +57,8 @@ optional_literal <- function(lit, label) {
     pSeq(
       function(value) { value[[2]][[1]][[1]] },
       pLiteral("_"), pLiteral(lit)
-    )
+    ),
+    max = 1
   )
 }
 
@@ -138,7 +140,8 @@ zero_or_one_of <- function(labels, label) {
       function(value) { value[[2]][[1]] },
       pLiteral("_"),
       do.call(pAlt, c(literals, tag = function(x) x))
-    )
+    ),
+    max = 1
   )
 }
 

--- a/man/optional_key.Rd
+++ b/man/optional_key.Rd
@@ -12,7 +12,7 @@ optional_key(label, regex = "[A-Za-z0-9]+")
 \item{regex}{A regex pattern that the key's value should match.}
 }
 \value{
-A parser that matches zero or more occurrences of \verb{_<label>-<id>}
+A parser that matches zero or one occurrence of \verb{_<label>-<id>}
 }
 \description{
 Create a parser for an optional BIDS key

--- a/tests/testthat/test_parse.R
+++ b/tests/testthat/test_parse.R
@@ -55,6 +55,10 @@ test_that("can parse various file types", {
   expect_type(encode("sub-sid000009_task-movie_run-03_space-MNI152Lin_res-native_desc-preproc_bold.nii.gz"), "list")
 })
 
+test_that("repeated tokens are not allowed", {
+  expect_null(encode("sub-01_task-rest_bold_bold.nii.gz"))
+})
+
 
 # sub-2001_T1w_brainmask.nii.gz						sub-2001_T1w_smoothwm.R.surf.gii
 # sub-2001_T1w_class-CSF_probtissue.nii.gz				sub-2001_T1w_space-MNI152NLin2009cAsym_brainmask.nii.gz


### PR DESCRIPTION
## Summary
- restrict optional key and literal parsers to a single match
- update docs for optional_key
- add test verifying repeated tokens fail to parse

## Testing
- `R` tests *(fails: R not installed)*