### PR TITLE
Add return docs and examples for spec helpers

### DIFF
--- a/R/specs.R
+++ b/R/specs.R
@@ -4,6 +4,10 @@
 #'   `keystruc` defines the keys and their regex patterns, and `kinds` defines 
 #'   the possible file types and suffixes.
 #' @param typename The name given to the final type element. Default is "kind".
+#' @return A parser function generated from the specification.
+#' @examples
+#' spec <- func_spec()
+#' parser <- gen_parser(spec)
 #' @keywords internal
 gen_parser <- function(spec, typename = "kind") {
   # Check input
@@ -116,6 +120,10 @@ gen_parser <- function(spec, typename = "kind") {
 #' defines keys, their regex patterns, their optionality, etc. The `kinds` table 
 #' defines allowed file kinds and their suffixes.
 #'
+#' @return A list containing `keystruc`, `kinds`, and `type` describing
+#'   functional files.
+#' @examples
+#' func_spec()
 #' @keywords internal
 func_spec <- function() {
   keystruc <- tibble::tribble(
@@ -145,6 +153,11 @@ func_spec <- function() {
 
 
 #' Create a spec table for "anat" files
+#'
+#' @return A list containing `keystruc`, `kinds`, and `type` describing
+#'   anatomical files.
+#' @examples
+#' anat_spec()
 #' @keywords internal
 anat_spec <- function() {
   keystruc <- tibble::tribble(
@@ -184,6 +197,11 @@ anat_spec <- function() {
 
 
 #' Create a spec table for fMRIPrep "func" files
+#'
+#' @return A list containing `keystruc`, `kinds`, and `type` describing
+#'   fMRIPrep functional files.
+#' @examples
+#' funcprepspec()
 #' @keywords internal
 funcprepspec <- function() {
   keystruc <- tibble::tribble(
@@ -227,6 +245,11 @@ funcprepspec <- function() {
 
 
 #' Create a spec table for fMRIPrep "anat" files
+#'
+#' @return A list containing `keystruc`, `kinds`, and `type` describing
+#'   fMRIPrep anatomical files.
+#' @examples
+#' anatprepspec()
 #' @keywords internal
 anatprepspec <- function() {
   anat_types <- c("defacemask","T1w", "T2w","T1map", "T2map", "T2star","FLAIR", "FLASH", "PDmap","PD","PDT2",
@@ -284,6 +307,11 @@ anatprepspec <- function() {
 
 
 #' Create a spec table for fieldmap files
+#'
+#' @return A list containing `keystruc`, `kinds`, and `type` describing
+#'   fieldmap files.
+#' @examples
+#' fmapspec()
 #' @keywords internal
 fmapspec <- function() {
   keystruc <- tibble::tribble(

--- a/man/anat_spec.Rd
+++ b/man/anat_spec.Rd
@@ -9,4 +9,10 @@ anat_spec()
 \description{
 Create a spec table for "anat" files
 }
+\value{
+A list containing \code{keystruc}, \code{kinds}, and \code{type} for anatomical files.
+}
+\examples{
+anat_spec()
+}
 \keyword{internal}

--- a/man/anatprepspec.Rd
+++ b/man/anatprepspec.Rd
@@ -9,4 +9,10 @@ anatprepspec()
 \description{
 Create a spec table for fMRIPrep "anat" files
 }
+\value{
+A list containing \code{keystruc}, \code{kinds}, and \code{type} for fMRIPrep anatomical files.
+}
+\examples{
+anatprepspec()
+}
 \keyword{internal}

--- a/man/fmapspec.Rd
+++ b/man/fmapspec.Rd
@@ -9,4 +9,10 @@ fmapspec()
 \description{
 Create a spec table for fieldmap files
 }
+\value{
+A list containing \code{keystruc}, \code{kinds}, and \code{type} for fieldmap files.
+}
+\examples{
+fmapspec()
+}
 \keyword{internal}

--- a/man/func_spec.Rd
+++ b/man/func_spec.Rd
@@ -12,4 +12,10 @@ It consists of a \code{keystruc} table and a \code{kinds} table. The \code{keyst
 defines keys, their regex patterns, their optionality, etc. The \code{kinds} table
 defines allowed file kinds and their suffixes.
 }
+\value{
+A list containing \code{keystruc}, \code{kinds}, and \code{type} for functional files.
+}
+\examples{
+func_spec()
+}
 \keyword{internal}

--- a/man/funcprepspec.Rd
+++ b/man/funcprepspec.Rd
@@ -9,4 +9,10 @@ funcprepspec()
 \description{
 Create a spec table for fMRIPrep "func" files
 }
+\value{
+A list containing \code{keystruc}, \code{kinds}, and \code{type} for fMRIPrep functional files.
+}
+\examples{
+funcprepspec()
+}
 \keyword{internal}

--- a/man/gen_parser.Rd
+++ b/man/gen_parser.Rd
@@ -13,7 +13,14 @@ the possible file types and suffixes.}
 
 \item{typename}{The name given to the final type element. Default is "kind".}
 }
+\value{
+A parser function generated from the specification.
+}
 \description{
 Given a match specification, generate a parser
+}
+\examples{
+spec <- func_spec()
+gen_parser(spec)
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- document returns for `gen_parser` and spec constructors
- add minimal examples to illustrate usage

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R CMD check` *(fails: command not found)*