### PR TITLE
Fix fmap_parser reference and test

### DIFF
--- a/R/matchers.R
+++ b/R/matchers.R
@@ -79,7 +79,7 @@ fmriprep_func_parser <- function() {
 #'
 #' @keywords internal
 fmap_parser <- function() {
-  spec <- fmap_spec()
+  spec <- fmapspec()
   parser <- gen_parser(spec)
   ret <- list(parser = parser)
   class(ret) <- c("fmap_parser", "parser")

--- a/repomix-output.txt
+++ b/repomix-output.txt
@@ -5073,7 +5073,7 @@ fmriprep_func_parser <- function() {
 #'
 #' @keywords internal
 fmap_parser <- function() {
-  spec <- fmap_spec()
+  spec <- fmapspec()
   parser <- gen_parser(spec)
   ret <- list(parser = parser)
   class(ret) <- c("fmap_parser", "parser")

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -5073,7 +5073,7 @@ fmriprep_func_parser <- function() {
 #'
 #' @keywords internal
 fmap_parser <- function() {
-  spec <- fmap_spec()
+  spec <- fmapspec()
   parser <- gen_parser(spec)
   ret <- list(parser = parser)
   class(ret) <- c("fmap_parser", "parser")

--- a/tests/testthat/test_fmap_parser.R
+++ b/tests/testthat/test_fmap_parser.R
@@ -1,0 +1,9 @@
+library(testthat)
+library(bidser)
+
+context("fmap_parser")
+
+test_that("fmap_parser can be constructed", {
+  obj <- fmap_parser()
+  expect_s3_class(obj, c("fmap_parser", "parser"))
+})


### PR DESCRIPTION
## Summary
- use `fmapspec()` when constructing fieldmap parser
- update cached outputs
- test `fmap_parser` creation

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` command not found)*