### PR TITLE
Add canonical confound aliases

### DIFF
--- a/man/read_confounds.bids_project.Rd
+++ b/man/read_confounds.bids_project.Rd
@@ -27,7 +27,7 @@
 
 \item{run}{Run regex}
 
-\item{cvars}{The names of the confound variables to select. Defaults to \code{DEFAULT_CVARS}.}
+\item{cvars}{The names of the confound variables to select. Defaults to \code{DEFAULT_CVARS}. Canonical names like \code{"csf"} are resolved to matching columns across fmriprep versions.}
 
 \item{npcs}{Perform PCA reduction on confounds and return \code{npcs} PCs.}
 
@@ -40,4 +40,10 @@ A nested tibble (if nest=TRUE) or a flat tibble (if nest=FALSE) of confounds.
 }
 \description{
 Reads in fmriprep confound tables for one or more subjects.
+}
+\examples{
+\donttest{
+proj <- bids_project("/path/to/bids", fmriprep = TRUE)
+conf <- read_confounds(proj, cvars = c("csf", "framewise_displacement"))
+}
 }

--- a/tests/testthat/test_read_confounds.R
+++ b/tests/testthat/test_read_confounds.R
@@ -63,3 +63,12 @@ test_that("nest=FALSE returns flat tibble", {
   expect_equal(nrow(flat), 3)
   expect_true(all(c("participant_id", "run", "session") %in% names(flat)))
 })
+
+test_that("canonical names resolve to dataset columns", {
+  setup <- create_confounds_proj()
+  on.exit(unlink(setup$path, recursive = TRUE, force = TRUE), add = TRUE)
+  conf <- read_confounds(setup$proj,
+                         cvars = c("csf", "white_matter", "framewise_displacement", "global_signal"))
+  cols <- names(conf$data[[1]])
+  expect_true(all(c("CSF", "WhiteMatter", "FramewiseDisplacement", "GlobalSignal") %in% cols))
+})


### PR DESCRIPTION
## Summary
- add `CVARS_ALIASES` constant for mapping canonical confound names to all known column variants
- implement `resolve_cvars()` to locate available column names using alias sets
- use `resolve_cvars()` in `read_confounds.bids_project`
- document alias resolution and add examples
- deprecate `DEFAULT_CVARS2`
- test canonical name resolution

## Testing
- `pre-commit` *(fails: command not found)*