### PR TITLE
Handle missing confound columns

### DIFF
--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -408,6 +408,11 @@ read_confounds.bids_project <- function(x, subid=".*", task=".*", session=".*", 
       # Resolve canonical confound names to available columns
       sel_cvars <- resolve_cvars(cvars, colnames(dfx))
 
+      if (length(sel_cvars) == 0) {
+        warning("No requested confounds were found for file: ", fn)
+        return(NULL)
+      }
+
       # Select requested confound columns
       dfx <- dfx %>% dplyr::select(any_of(sel_cvars))
       

--- a/tests/testthat/test_read_confounds.R
+++ b/tests/testthat/test_read_confounds.R
@@ -72,3 +72,11 @@ test_that("canonical names resolve to dataset columns", {
   cols <- names(conf$data[[1]])
   expect_true(all(c("CSF", "WhiteMatter", "FramewiseDisplacement", "GlobalSignal") %in% cols))
 })
+
+test_that("file without requested confounds is skipped", {
+  setup <- create_confounds_proj()
+  on.exit(unlink(setup$path, recursive = TRUE, force = TRUE), add = TRUE)
+  expect_warning(res <- read_confounds(setup$proj, cvars = "junkvar"),
+                 "No requested confounds")
+  expect_null(res)
+})


### PR DESCRIPTION
## Summary
- warn and skip confound files with none of the requested columns
- test skipping of files lacking the specified confounds

## Testing
- `devtools::test()` *(fails: command not found)*