### PR TITLE
Replace exists check with direct encode call

### DIFF
--- a/R/mock_bids.R
+++ b/R/mock_bids.R
@@ -504,19 +504,9 @@ create_mock_bids <- function(project_name,
     relative_path <- file.path(relative_dir, filename)
 
     # Use bidser::encode to get canonical entities (important!)
-    # Requires bidser to be loaded or use :::
+    # Call directly and handle any errors
     encoded_entities <- tryCatch({
-        # Use internal encode if possible, otherwise assume global ::
-         if (exists("encode", envir = environment(create_mock_bids), inherits = FALSE)) {
-             result <- bidser::encode(filename)
-             result
-         } else {
-             # Fallback if running outside package context? Risky.
-              # This requires the bidser package to be loaded globally.
-             # A safer approach is to ensure this function is part of the bidser pkg.
-              result <- encode(filename) # Assumes bidser::encode is available
-              result
-         }
+        bidser::encode(filename)
     }, error = function(e) {
         warn(paste("Could not encode generated filename:", filename, " - May impact querying. Error:", e$message))
         # Fallback: use entities from file_structure row directly with standardized names


### PR DESCRIPTION
## Summary
- simplify encoding by removing fallback to `encode`
- directly call `bidser::encode` and warn on failure

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*