### PR TITLE
Fix participants fallback to participants.tsv

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -390,8 +390,10 @@ tasks.bids_project <- function(x) {
 #' @export
 #' @rdname participants-method
 participants.bids_project <- function(x, ...) {
-  if ("subid" %in% names(x$tbl)) {
+  if ("subid" %in% names(x$tbl) && any(!is.na(x$tbl$subid))) {
     unique(x$tbl$subid[!is.na(x$tbl$subid)])
+  } else if ("participant_id" %in% names(x$part_df)) {
+    unique(as.character(x$part_df$participant_id))
   } else {
     character(0)
   }


### PR DESCRIPTION
## Summary
- fix `participants.bids_project` to use `participants.tsv` when tree lacks participant info

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*