### PR TITLE
Fix mask search in preproc mask

### DIFF
--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -181,10 +181,10 @@ create_preproc_mask.bids_project <- function(x, subid, thresh=.99, mask_kinds = 
   
   maskfiles <- c()
   if ("brainmask" %in% mask_kinds) {
-    maskfiles <- c(maskfiles, search_files(x, subid = subid, deriv = "brainmask", full_path = TRUE, ...))
+    maskfiles <- c(maskfiles, search_files(x, subid = subid, kind = "brainmask", full_path = TRUE, ...))
   }
   if ("mask" %in% mask_kinds) {
-    maskfiles <- c(maskfiles, search_files(x, subid = subid, deriv = "mask", desc = "brain", full_path = TRUE, ...))
+    maskfiles <- c(maskfiles, search_files(x, subid = subid, kind = "mask", desc = "brain", full_path = TRUE, ...))
   }
   maskfiles <- unique(maskfiles)
   if (length(maskfiles) == 0) {


### PR DESCRIPTION
## Summary
- use `kind` instead of `deriv` when locating brainmask files in `create_preproc_mask.bids_project`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`