### PR TITLE
Fix str_detect_null and key_match handling

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -522,11 +522,7 @@ str_detect_null <- function(x, pat, default=FALSE) {
   if (is.null(x) || is.na(x)) {
     return(default)
   }
-  # Ensure x is character before passing to str_detect
-  if (!is.character(x)) {
-    x <- as.character(x)
-  }
-  stringr::str_detect(x, pat)
+  stringr::str_detect(as.character(x), pat)
 }
 
 #' Get preprocessed scans from a BIDS project
@@ -680,9 +676,9 @@ key_match <- function(default=FALSE, ...) {
         return(TRUE)
       }
       
-      # Ensure x[[k]] is character if it's not NULL/NA, before passing to str_detect_null
+      # Convert value to character when not NULL/NA before pattern matching
       node_val <- x[[k]]
-      if (!is.null(node_val) && !is.na(node_val) && !is.character(node_val)) {
+      if (!is.null(node_val) && !is.na(node_val)) {
         node_val <- as.character(node_val)
       }
 


### PR DESCRIPTION
## Summary
- ensure `str_detect_null()` always uses `stringr::str_detect(as.character(x))`
- coerce node values to character before calling `str_detect_null()`

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test_events.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b9b52c014832d83f0a4fde5db5e8f