### PR TITLE
Fix func_scans output for vignettes

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -509,8 +509,8 @@ func_scans.bids_project <- function (x, subid=".*", task=".*", run = ".*", sessi
   
   ret <- x$bids_tree$children$raw$Get(f, filterFun = function(z) {
     if (z$isLeaf && !is.null(z$task) &&  !is.null(z$type) && str_detect_null(z$kind,kind)
-        && str_detect_null(z$subid, subid)  && str_detect_null(z$task, task) 
-        && str_detect_null(z$session, session, default=TRUE) 
+        && str_detect_null(z$subid, subid)  && str_detect_null(z$task, task)
+        && str_detect_null(z$session, session, default=TRUE)
         && str_detect_null(z$run, run, default=TRUE) && str_detect_null(z$suffix, "nii(.gz)?$")) {
       TRUE
     } else {
@@ -518,16 +518,17 @@ func_scans.bids_project <- function (x, subid=".*", task=".*", run = ".*", sessi
     }
   })
   
-  #ret <- names(ret)
-  #paths <- sapply(stringr::str_split(ret, "_"), function(sp) {
-  #  paste0(sp[[1]], "/", sp[[2]], "/func")
-  #})
-  #paste0(paths, "/", ret)
-  if (full_path && !is.null(ret)) {
-    ret <- paste0(x$path, "/", ret)
+  if (length(ret) == 0) {
+    return(NULL)
   }
-  
-  unname(ret)
+
+  ret <- unique(unname(unlist(ret)))
+
+  if (full_path) {
+    ret <- file.path(x$path, ret)
+  }
+
+  as.vector(ret)
 }
 
 

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -116,7 +116,7 @@ If we are only interested in functional bolds scans (rather than any file with "
 fscans <- func_scans(proj)
 
 ## take the first 5 files, since there are alot.
-fscans <- head(bold, 5)
+fscans <- head(fscans, 5)
 ```
 
 ```{r, echo=FALSE, results='asis'} 


### PR DESCRIPTION
## Summary
- ensure `func_scans` returns a character vector
- correct example in vignette

## Testing
- `R CMD check .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d71c0cc832d837450c4929bb5d4