### PR TITLE
Fix vignette issue when no subject 16 scans

### DIFF
--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -132,9 +132,13 @@ fscans_16 <- func_scans(proj, subid="16")
 
 ```
 
-```{r, echo=FALSE, results='asis'} 
+```{r, echo=FALSE, results='asis'}
 
-gluedown::md_bullet(basename(fscans_16))
+if (length(fscans_16) > 0) {
+  gluedown::md_bullet(basename(fscans_16))
+} else {
+  cat("No scans found for subject 16\n")
+}
 ```
 
 ## Reading in Task Event files


### PR DESCRIPTION
## Summary
- fix `quickstart.Rmd` vignette chunk to handle missing subject scans gracefully

## Testing
- `bash: R: command not found`

------
https://chatgpt.com/codex/tasks/task_e_683f6580f124832db097a5b4d9e2f209