### PR TITLE
Fix docs and examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
   stringr,
   data.tree,
   neuroim2,
-  progress,
   tidyselect,
   dplyr,
   ggplot2,

--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -473,6 +473,7 @@ func_scans <- function(x, ...) {
 #' @param subid Subject ID regex to match specific subjects (default: ".*" for all subjects)
 #' @param task Task regex to match specific tasks (default: ".*" for all tasks)
 #' @param run Run regex to match specific runs (default: ".*" for all runs)
+#' @param session Session regex to match specific sessions (default: ".*" for all sessions)
 #' @param variant Preprocessing variant to match (default: NULL, which matches files without a variant)
 #' @param space Space regex to match specific spaces (default: ".*" for all spaces)
 #' @param modality Image modality to match (default: "bold" for functional MRI)

--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -366,7 +366,7 @@ confound_files.bids_project <- function(x, subid=".*", task=".*", session=".*", 
 #' @importFrom tidyselect any_of
 #' @return A nested tibble (if nest=TRUE) or a flat tibble (if nest=FALSE) of confounds.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' proj <- bids_project("/path/to/bids", fmriprep = TRUE)
 #' # canonical names automatically resolve to actual columns
 #' conf <- read_confounds(proj, cvars = c("csf", "framewise_displacement"))

--- a/man/preproc_scans-method.Rd
+++ b/man/preproc_scans-method.Rd
@@ -27,6 +27,8 @@ preproc_scans(
 
 \item{run}{Run regex to match specific runs (default: ".*" for all runs)}
 
+\item{session}{Session regex to match specific sessions (default: ".*" for all sessions)}
+
 \item{variant}{Preprocessing variant to match (default: NULL, which matches files without a variant)}
 
 \item{space}{Space regex to match specific spaces (default: ".*" for all spaces)}

--- a/man/read_confounds.bids_project.Rd
+++ b/man/read_confounds.bids_project.Rd
@@ -48,7 +48,7 @@ A nested tibble (if nest=TRUE) or a flat tibble (if nest=FALSE) of confounds.
 Reads in fmriprep confound tables for one or more subjects.
 }
 \examples{
-\donttest{
+\dontrun{
 proj <- bids_project("/path/to/bids", fmriprep = TRUE)
 # canonical names automatically resolve to actual columns
 conf <- read_confounds(proj, cvars = c("csf", "framewise_displacement"))


### PR DESCRIPTION
## Summary
- document session parameter in preproc_scans
- mark read_confounds example as `\dontrun`
- drop unused `progress` package

## Testing
- `devtools::document()` *(fails: R not installed)*
- `devtools::check()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840c51ee18c832d87b11e1ac96c0199