### PR TITLE
Add rdname tags and missing examples

### DIFF
--- a/R/bidsio.R
+++ b/R/bidsio.R
@@ -9,6 +9,22 @@
 #' @param modality The image modality (usually "bold")
 #' @param ... Extra arguments passed to \code{neuroim2::read_vec}
 #' @return An instance of type \code{NeuroVec}
+#' @rdname read_func_scans
+#' @examples
+#' \donttest{
+#' tryCatch({
+#'   ds_path <- get_example_bids_dataset("ds000001-fmriprep")
+#'   proj <- bids_project(ds_path, fmriprep=TRUE)
+#'   mask <- brain_mask(proj, subid="01")
+#'   vec <- read_func_scans.bids_project(proj, mask,
+#'                                      subid="01",
+#'                                      task="balloonanalogrisktask",
+#'                                      run="01")
+#'   unlink(ds_path, recursive=TRUE)
+#' }, error = function(e) {
+#'   message("Example requires derivatives dataset: ", e$message)
+#' })
+#' }
 #' @export
 read_func_scans.bids_project <- function(x, mask, mode = c("normal", "bigvec"),
                                          subid="^sub-.*", task=".*", run = ".*", modality="bold", ...) {
@@ -312,6 +328,7 @@ resolve_cvars <- function(cvars, col_names, rename = FALSE) {
 #' @param session Session regex
 #' @param ... Additional arguments (not currently used)
 #' @return A character vector of file paths
+#' @rdname confound_files-method
 #' @export
 confound_files.bids_project <- function(x, subid=".*", task=".*", session=".*", ...) {
   if (!inherits(x, "bids_project")) {

--- a/R/mock_bids.R
+++ b/R/mock_bids.R
@@ -1043,6 +1043,7 @@ tasks.mock_bids_project <- function(x, ...) {
 #' @param ... Additional BIDS entities to match (e.g., `subid = "01"`, `task = "rest"`).
 #'        Values are treated as regex patterns unless they are simple strings without regex characters.
 #' @return A character vector of matching file paths, or `NULL` if no matches.
+#' @rdname search_files
 #' @export
 search_files.mock_bids_project <- function(x, regex = ".*", full_path = FALSE, strict = TRUE, ...) {
   # Extract fmriprep parameter if provided
@@ -1280,6 +1281,7 @@ preproc_scans.mock_bids_project <- function(x, subid = ".*", task = ".*", run = 
 #' @param ... Additional arguments passed to `event_files`.
 #' @return A nested tibble with columns `.subid`, `.task`, `.run`, `.session` (if applicable),
 #'   and `data` (containing the event tibbles), or an empty tibble if no matching data.
+#' @rdname read_events-method
 #' @export
 read_events.mock_bids_project <- function(x, subid = ".*", task = ".*", run = ".*", session = ".*", ...) {
 
@@ -1488,6 +1490,7 @@ confound_files.mock_bids_project <- function(x, subid = ".*", task = ".*", sessi
 #' @param nest If `TRUE`, returns a nested tibble keyed by subject, session and run.
 #' @param ... Additional BIDS entities (passed to `search_files`).
 #' @return A tibble of confound data (nested if `nest = TRUE`).
+#' @rdname read_confounds-method
 #' @export
 read_confounds.mock_bids_project <- function(x, subid = ".*", task = ".*", session = ".*", run = ".*",
                                              cvars = NULL, npcs = -1, perc_var = -1, nest = TRUE, ...) {


### PR DESCRIPTION
## Summary
- link S3 methods to generic documentation via `@rdname`
- provide example usage for `read_func_scans.bids_project`

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684424d4be34832d82b0a707f55ea988