### PR TITLE
Improve whitespace-delimited event file handling

### DIFF
--- a/R/bids.R
+++ b/R/bids.R
@@ -1153,7 +1153,7 @@ match_attribute <- function(x, ...) {
 #' @rdname load_all_events-method
 #' @importFrom dplyr bind_rows mutate
 #' @importFrom stringr str_match
-#' @importFrom readr read_tsv
+#' @importFrom readr read_delim
 #' @importFrom tibble tibble
 #' @export
 load_all_events.bids_project <- function(x, subid=".*", task=".*", run=".*", session=".*", full_path=TRUE, ...) {
@@ -1192,7 +1192,7 @@ load_all_events.bids_project <- function(x, subid=".*", task=".*", run=".*", ses
   df_list <- lapply(event_files, function(fn) {
     meta <- parse_metadata(fn)
     dfx <- tryCatch({
-      readr::read_tsv(fn, na = c("n/a", "NA"))
+      readr::read_delim(fn, delim = " ", na = c("n/a", "NA"))
     }, error = function(e) {
       warning("Failed to read file: ", fn, " - ", e$message)
       return(NULL)

--- a/R/events.R
+++ b/R/events.R
@@ -83,7 +83,7 @@ event_files.bids_project <- function(x, subid=".*", task=".*", run=".*", session
 #' @importFrom magrittr %>%
 #' @importFrom stringr str_detect
 #' @importFrom rlang .data
-#' @importFrom readr read_tsv
+#' @importFrom readr read_delim
 #' @examples
 #' \donttest{
 #' # Create a BIDS project object
@@ -218,7 +218,7 @@ read_events.bids_project <- function(x, subid=".*", task=".*", run=".*", session
       event_data <- vector("list", length(evs))
       for (k in seq_along(evs)) {
         df <- tryCatch({
-          readr::read_tsv(evs[k], na = c("n/a", "NA", "N/A", ""))
+          readr::read_delim(evs[k], delim = " ", na = c("n/a", "NA", "N/A", ""))
         }, error = function(e) {
           warning("Failed to read event file: ", evs[k], " - ", e$message)
           NULL


### PR DESCRIPTION
## Summary
- switch event reading from `read_tsv` to `read_delim` using a space delimiter

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685170720c74832daaf49512ef6fd37b